### PR TITLE
Add automation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,11 +16,11 @@ jobs:
       - name: Set Up Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: uc-python
+          activate-environment: cincinnati-insurance-training
           environment-file: environment.yml
       - name: Set Up Jupyter Kernel
         run: |
-          python -m ipykernel install --user --name uc-python
+          python -m ipykernel install --user --name cincinnati-insurance-training
       - name: Install Papermill
         run: |
           conda install papermill

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,38 @@
+name: Test
+
+on: push
+
+jobs:
+  validate-notebooks:
+    name: Validate Notebooks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Required for "run" commands to execute in the conda env.
+        shell: bash -l {0}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set Up Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: uc-python
+          environment-file: environment.yml
+      - name: Set Up Jupyter Kernel
+        run: |
+          python -m ipykernel install --user --name uc-python
+      - name: Install Papermill
+        run: |
+          conda install papermill
+      - name: Prep notebooks
+        run: |
+          # Remove nb cells that should be skipped in CI.
+          for nb in notebooks/*.ipynb; do
+            python scripts/prep_nb_for_ci.py "$nb"
+          done
+      - name: Run notebooks
+        run: |
+          for nb in notebooks/*.ipynb; do
+            echo "running $nb"
+            output=$(papermill --cwd notebooks/ "$nb" -)
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Custom
+/slides

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+slides: slides/.finished
+slides/.finished: $(wildcard notebooks/**/*)
+	bash scripts/generate_slides.sh
+	touch slides/.finished
+
+clean:
+	rm -rf slides/

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: cincinnati-insurance-training
 channels:
     - defaults
+    - conda-forge
 dependencies:
     - python>=3.10
     - pip>=22.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: cincinnati-insurance-training
+channels:
+    - defaults
+dependencies:
+    - python>=3.10
+    - pip>=22.1
+    - nbconvert>=7.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,6 @@ channels:
     - conda-forge
 dependencies:
     - python>=3.10
+    - ipykernel>=6.0
     - pip>=22.1
     - nbconvert>=7.0

--- a/notebooks/00-Intro.ipynb
+++ b/notebooks/00-Intro.ipynb
@@ -420,9 +420,9 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "uc-python",
+   "display_name": "cincinnati-insurance-training",
    "language": "python",
-   "name": "uc-python"
+   "name": "cincinnati-insurance-training"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/00-Intro.ipynb
+++ b/notebooks/00-Intro.ipynb
@@ -1,0 +1,446 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Introduction to Python for Data Science\n",
+    "\n",
+    "Ethan Swan & Brad Boehmke\n",
+    "\n",
+    "March 9, 11, 16, 18"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Introductions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## About Brad\n",
+    "<table><tr>\n",
+    "    <td><img width=\"300\" src=\"images/brad.jpg\"></td>\n",
+    "    <td>\n",
+    "      <h4>Professional</h4>\n",
+    "      <ul>\n",
+    "          <li>Director, Advanced Programming and Technology Solutions Team</li>\n",
+    "          <li>84.51&deg;</li>\n",
+    "      </ul>\n",
+    "      <h4>Academic</h4>\n",
+    "      <ul>\n",
+    "          <li>BS, Kinesiology, North Dakota State University</li>\n",
+    "          <li>MS, Cost Analytics, Air Force Institute of Technology</li>\n",
+    "          <li>PhD, Logistics, Air Force Institute of Technology</li>\n",
+    "      </ul>\n",
+    "      <h4>Contact</h4>\n",
+    "      <ul>\n",
+    "          <li>Website: <a href=\"http://bradleyboehmke.github.io/\">bradleyboehmke.github.io</a></li>\n",
+    "          <li>GitHub: <a href=\"https://github.com/bradleyboehmke\">bradleyboehmke</a></li>\n",
+    "          <li>Twitter: <a href=\"https://twitter.com/bradleyboehmke\">@bradleyboehmke</a></li>\n",
+    "          <li>LinkedIn: <a href=\"https://www.linkedin.com/in/brad-boehmke-ph-d-9b0a257\">Brad Boehmke, PhD</a></li>\n",
+    "          <li>Email: <a href=\"mailto:bradleyboehmke@gmail.com\">bradleyboehmke@gmail.com</a></li>\n",
+    "      </ul>\n",
+    "    </td>\n",
+    "</tr></table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## About Ethan\n",
+    "<table><tr>\n",
+    "  <td><img width=\"300\" src=\"images/ethan.jpg\"></td>\n",
+    "  <td>\n",
+    "      <h4>Professional</h4>\n",
+    "      <ul>\n",
+    "          <li>Associate Fullstack Developer</li>\n",
+    "          <li>ReviewTrackers</li>\n",
+    "      </ul>\n",
+    "      <h4>Academic</h4>\n",
+    "      <ul>\n",
+    "          <li>BS, Computer Science, University of Notre Dame</li>\n",
+    "          <li>MBA, Business Analytics, University of Notre Dame</li>\n",
+    "      </ul>\n",
+    "      <h4>Contact</h4>\n",
+    "      <ul>\n",
+    "          <li>Website: <a href=\"https://ethanswan.com\">ethanswan.com</a></li>\n",
+    "          <li>GitHub: <a href=\"https://github.com/eswan18/\">eswan18</a></li>\n",
+    "          <li>Twitter: <a href=\"https://twitter.com/eswan18\">@eswan18</a></li>\n",
+    "          <li>LinkedIn: <a href=\"https://linkedin.com/in/ethanpswan\">Ethan Swan</a></li>\n",
+    "          <li>Email: <a href=\"mailto:ethanpswan@gmail.com\">ethanpswan@gmail.com</a></li>\n",
+    "      </ul>\n",
+    "    </td>\n",
+    "</tr></table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Around The Room\n",
+    "\n",
+    "We'll go around the room. Please share:\n",
+    "\n",
+    "1. Your name\n",
+    "2. Your job or field\n",
+    "3. How you use Python now or would like to in the future"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Course"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Defining Data Science\n",
+    "\n",
+    "<center>\n",
+    "<img src=\"images/data-science.png\" alt=\"data-science.png\" width=\"900\" height=\"900\">\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Data Science and Technology\n",
+    "\n",
+    "<center>\n",
+    "<img src=\"images/data-science-and-tech.png\" alt=\"data-science-and-tech.png\" width=\"1100\" height=\"1100\">\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Applied Data Science\n",
+    "\n",
+    "<center>\n",
+    "<img src=\"images/applied-data-science.gif\" alt=\"applied-data-science.gif\" width=\"1200\" height=\"1200\">\n",
+    "</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Course Objectives\n",
+    "\n",
+    "The following are the primary learning objectives of this course:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "1. Develop comprehensive skills in the importing/exporting, wrangling, aggregating and joining of data using Python.\n",
+    "2. Establish a mental model of the Python programming language to enable future self-learning.\n",
+    "3. Build awareness and basic skills in the core data science area of data visualization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Course Agenda"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "| Day       | Topic                                                                          |     Time      |\n",
+    "| :--------:| :----------------------------------------------------------------------------- | :-----------: |\n",
+    "| __Day 1__ | Introductions                                                                  |  9:00 - 9:15  |\n",
+    "|           | Python and Jupyter Overview                                                    |  9:15 - 9:45  |\n",
+    "|           | Fundamentals                                                                   |  9:45 - 10:30 |\n",
+    "|           | Break                                                                          | 10:30 - 10:45 |\n",
+    "|           | Packages, Modules, Methods, Functions                                          | 10:45 - 11:30 |\n",
+    "|           | Importing Data                                                                 | 11:30 - 12:00 |\n",
+    "|           | Q\\&A                                                                           | 12:00 - 12:30 |\n",
+    "| __Day 2__ | Q\\&A                                                                           |  8:30 - 9:00  |\n",
+    "|           | Selecting and Filtering Data                                                   |  9:00 - 10:00 |\n",
+    "|           | Working with Columns                                                           | 10:00 - 10:45 |\n",
+    "|           | Break                                                                          | 10:45 - 11:00 |\n",
+    "|           | Case Study, pt. 1                                                              | 11:00 - 12:00 |\n",
+    "|           | Q\\&A                                                                           | 12:00 - 12:30 |\n",
+    "| __Day 3__ | Q\\&A                                                                           |  8:30 - 9:00  |\n",
+    "|           | Review                                                                         |  9:00 - 9:30  |\n",
+    "|           | Summarizing Data                                                               |  9:30 - 10:30 |\n",
+    "|           | Break                                                                          | 10:30 - 10:45 |\n",
+    "|           | Summarizing Grouped Data                                                       | 10:45 - 11:15 |\n",
+    "|           | Joining Data                                                                   | 11:15 - 12:00 |\n",
+    "|           | Q\\&A                                                                           | 12:00 - 12:30 |\n",
+    "| __Day 4__ | Q\\&A                                                                           |  8:30 - 9:00  |\n",
+    "|           | Exporting Data                                                                 |  9:00 - 9:30  |\n",
+    "|           | Visualizing Data                                                               |  9:30 - 10:30 |\n",
+    "|           | Break                                                                          | 10:30 - 10:45 |\n",
+    "|           | Case Study, pt. 2                                                              | 10:45 - 11:30 |\n",
+    "|           | Q\\&A                                                                           | 11:30 - 12:00 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Technologies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "cell_style": "center",
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Binder\n",
+    "\n",
+    "* We've developed this class using a product named [Binder](https://mybinder.org/).\n",
+    "* As a result, this course requires *zero* setup on your part.\n",
+    "* There are two core techologies within the Binder repository: Python and Jupyter.\n",
+    "\n",
+    "*We will cover more on this shortly.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "cell_style": "split",
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Python\n",
+    "\n",
+    "* Python is the programming language we'll be learning in this class.\n",
+    "* We are using Python 3.9, the newest version of Python, for the entirety of this class.\n",
+    "* The core libaries we will be using are `pandas` and `seaborn`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "cell_style": "split",
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "### Jupyter\n",
+    "\n",
+    "* Jupyter is the integrated development environment (IDE) we will be using.\n",
+    "* This is where we will write and run our Python code.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Course Material"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* All of the material for this course can be reached from our [GitHub](https://github.com/uc-python/intro-python-datasci) repository."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* You can either access this material through [Binder](https://mybinder.org/v2/gh/uc-python/intro-python-datasci/master) or by [downloading the material](https://github.com/uc-python/intro-python-datasci/archive/master.zip)\n",
+    " and opening it via Anaconda Navigator and JupyterLab."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Slides *are* notebooks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* We will be teaching using slides."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* These slides are created from the notebooks in the course repository -- so you can follow along and run the code in your notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Source Code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* Source code for the training can be found on [GitHub](https://github.com/uc-python/intro-python-datasci)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* This repository is public so you can clone (download) and/or refer to the materials at any point in the future."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Questions\n",
+    "\n",
+    "Are there any questions before moving on?"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "uc-python",
+   "language": "python",
+   "name": "uc-python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "rise": {
+   "autolaunch": true,
+   "transition": "none"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -d ".git" ]; then
+    echo "Error: no .git directory detected"
+    echo "This script should be run from the base of the repo"
+    echo 'e.g. `bash scripts/generate_slides.sh`'
+    exit 1
+fi
+
+# We must be *in* the notebook folder for relative links (to eg images) to work
+# correctly..
+cd notebooks
+mkdir -p ../slides/images/
+cp -a ./images/* ../slides/images/
+# Match all notebook files with content.
+for file in *-*.ipynb; do
+    jupyter nbconvert --to slides $file --output-dir=../slides
+done

--- a/scripts/prep_nb_for_ci.py
+++ b/scripts/prep_nb_for_ci.py
@@ -1,0 +1,31 @@
+# Replace a notebook, with cells tagged ci-skip removed.
+# Adapted from https://stackoverflow.com/questions/62022603/how-to-delete-a-jupyter-notebook-input-cell-programmatically-using-its-tag
+
+import sys
+import nbformat
+
+SKIP_TAG = 'ci-skip'
+
+if len(sys.argv) != 2:
+    raise Exception('Usage: prep_nb_for_ci [notebook.ipynb]')
+nb_file = sys.argv[1]
+
+nb = nbformat.read(nb_file, as_version=nbformat.NO_CONVERT)
+
+tagged_cell_indices = []
+
+# find index for the cell with the injected params
+for idx, cell in enumerate(nb.cells):
+    cell_tags = cell.metadata.get('tags')
+    if cell_tags:
+        if SKIP_TAG in cell_tags:
+            tagged_cell_indices.append(idx)
+
+# Remove tagged cells.
+# Iterate in reverse because deleting an earlier index will change what cell
+# is at a later one.
+for idx in reversed(tagged_cell_indices):
+    nb.cells.pop(idx)
+
+# Overwrite the original.
+nbformat.write(nb, nb_file)


### PR DESCRIPTION
This PR accomplishes two goals:
1. Have an automated way to turn notebooks into slides. This is now done with simply running `make`, or more verbosely by running `bash scripts/generate_slides.sh` for those of you who hate the legacy of Bell Laboratories.
2. Test notebooks to make sure that the code is valid. This will now happen automatically in GitHub Actions. Notebooks are run in Papermill, but first any cells tagged with `ci-skip` are removed – this allows us to have some cells with intentional errors for demo purposes.

In terms of implementation details, here are the new files:
- `notebooks/00-Intro.ipynb`: a notebook copied straight from the intro class just to get these scripts to run. Will be updated as part of #2 .
- `Makefile`: supports `make slides` (which is also the default when you just run `make`). Also supports `make clean` to clear out your `slides/` directory.
- `scripts/generate_slides.sh`: just runs nbconvert to turn notebooks into slides, and copies images into `slides` directory so that relative paths still work.
- `.gitignore`: don't commit slides, they're basically compiled output
- `scripts/prep_nb_for_ci.py`: modifies notebooks in-place to remove all cells with `ci-skip` tags. This is only meant to be run in GH Actions and it prepares notebooks to be "tested" by running them through Papermill and checking for errors.
- `.github/workflows/test.yaml`: GH Action for testing notebooks with Papermill
- `environment.yaml`: a very basic environment, just enough to get CI working. We can add to this as we go.