### PR TITLE
Add new environment spec.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,7 @@ dependencies:
     - ipykernel>=6.0
     - pip>=22.1
     - nbconvert>=7.0
+    - numpy>=1.24
+    - pandas>=1.5
+    - matplotlib>=3.6
+    - seaborn>=0.12


### PR DESCRIPTION
This PR adds a new `environment.yaml` file requiring Python 3.10+ and the latest minor versions of:
- numpy
- pandas
- matplotlib
- seaborn

It requires access to conda-forge since the regular anaconda repository tends to lag a couple of versions behind.