### PR TITLE
Update environment to play nice with VSCode.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,4 @@ dependencies:
     - pandas>=1.5
     - matplotlib>=3.6
     - seaborn>=0.12
-    - ipykernel>=6.20
     - notebook>=6.0

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,5 @@ dependencies:
     - pandas>=1.5
     - matplotlib>=3.6
     - seaborn>=0.12
+    - ipykernel>=6.20
+    - notebook>=6.0


### PR DESCRIPTION
Foolishly, when I made the new environment yesterday, I didn't actually try to use it in VSCode. Not knowing much about notebooks in VSCode, I assumed it just started the underlying Python executable and didn't need a kernel but today I learned I was wrong when I try to run some code. This adds the dependencies that VSCode complains about, and after switching to this file, I was able to get code to run in a notebook.