### PR TITLE
Makefile Updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,6 @@ If you want to just build slides for a single notebook, you can call `nbconvert`
 jupyter nbconvert --to slides <notebookname.ipynb> --output-dir=../slides
 ```
 
-*n.b.* There seems to be a bug in the `make slides` directive and it sometimes reports "Nothing to be done for `slides'."
-Run `make clean && make slides` instead to fix the problem.
-
 ## Notebook Naming Convention
 
 In order to keep notebooks ordered, we prefix them with a 2-digit "code" indicating where in the sequence they fall.

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
-slides: images html
-
 IMAGESIN=$(wildcard notebooks/images/*)
 IMAGESOUT=$(patsubst notebooks/%,slides/%,$(IMAGESIN))
+NBFILES=$(wildcard notebooks/*-*.ipynb)
+HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))
+
+slides: images html
 
 images: $(IMAGESOUT)
 
 $(IMAGESOUT): slides/images/%: notebooks/images/%
 	mkdir -p slides/images
 	cp $< $@
-
-NBFILES=$(wildcard notebooks/*-*.ipynb)
-HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))
 
 html: $(HTMLFILES)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-slides: slides/.finished
-slides/.finished: $(wildcard notebooks/**/*)
-	bash scripts/generate_slides.sh
-	touch slides/.finished
+slides: html
+
+NBFILES=$(wildcard notebooks/*-*.ipynb)
+HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))
+
+html: $(HTMLFILES)
+
+$(HTMLFILES): slides/%.slides.html: notebooks/%.ipynb
+	bash scripts/generate_slides.sh $<
 
 clean:
 	rm -rf slides/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ slides/images:
 	mkdir -p slides/images
 
 $(IMAGESOUT): slides/images/%: notebooks/images/%
-	cp $< $@
+	cp -a $< $@
 
 html: images $(HTMLFILES)
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))
 
 slides: html
 
-images: $(IMAGESOUT)
+images: slides/images $(IMAGESOUT)
+
+slides/images:
+	mkdir -p slides/images
 
 $(IMAGESOUT): slides/images/%: notebooks/images/%
-	mkdir -p slides/images
 	cp $< $@
 
 html: images $(HTMLFILES)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-slides: html
+slides: images html
+
+IMAGESIN=$(wildcard notebooks/images/*)
+IMAGESOUT=$(patsubst notebooks/%,slides/%,$(IMAGESIN))
+
+images: $(IMAGESOUT)
+
+$(IMAGESOUT): slides/images/%: notebooks/images/%
+	mkdir -p slides/images
+	cp $< $@
 
 NBFILES=$(wildcard notebooks/*-*.ipynb)
 HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGESOUT=$(patsubst notebooks/%,slides/%,$(IMAGESIN))
 NBFILES=$(wildcard notebooks/*-*.ipynb)
 HTMLFILES=$(patsubst notebooks/%.ipynb,slides/%.slides.html,$(NBFILES))
 
-slides: images html
+slides: html
 
 images: $(IMAGESOUT)
 
@@ -11,7 +11,7 @@ $(IMAGESOUT): slides/images/%: notebooks/images/%
 	mkdir -p slides/images
 	cp $< $@
 
-html: $(HTMLFILES)
+html: images $(HTMLFILES)
 
 $(HTMLFILES): slides/%.slides.html: notebooks/%.ipynb
 	bash scripts/generate_slides.sh $<

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -13,6 +13,9 @@ cd notebooks
 mkdir -p ../slides/images/
 cp -a ./images/* ../slides/images/
 # Match all notebook files with content.
-for file in *-*.ipynb; do
-    jupyter nbconvert --to slides $file --output-dir=../slides
-done
+#for file in *-*.ipynb; do
+#    jupyter nbconvert --to slides $file --output-dir=../slides
+#done
+NB_PATH="$1"
+REL_NB=${NB_PATH//notebooks\//}
+jupyter nbconvert --to slides $REL_NB --output-dir=../slides

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -12,5 +12,5 @@ fi
 cd notebooks
 # images are copied over to slides/ by the Makefile
 NB_PATH="$1"
-REL_NB=${NB_PATH//notebooks\//}
+REL_NB=${NB_PATH/#notebooks\//}
 jupyter nbconvert --to slides $REL_NB --output-dir=../slides

--- a/scripts/generate_slides.sh
+++ b/scripts/generate_slides.sh
@@ -10,12 +10,7 @@ fi
 # We must be *in* the notebook folder for relative links (to eg images) to work
 # correctly..
 cd notebooks
-mkdir -p ../slides/images/
-cp -a ./images/* ../slides/images/
-# Match all notebook files with content.
-#for file in *-*.ipynb; do
-#    jupyter nbconvert --to slides $file --output-dir=../slides
-#done
+# images are copied over to slides/ by the Makefile
 NB_PATH="$1"
 REL_NB=${NB_PATH//notebooks\//}
 jupyter nbconvert --to slides $REL_NB --output-dir=../slides


### PR DESCRIPTION
Closes #34 

Cracked the code on the Makefile updates. Tested against no `slides/`, as well as updating one or multiple notebooks.

- Maps notebooks to corresponding HTML file, so the conversion is only done for updated files
- Similarly mapped the images, so only new/updated images are copied
  - Obviously, this doesn't check if the new images is actually used, but that feels fine, just a little potential clutter
- Stealth add: can now run `make html`, which gives the same thing as `make slides`, but also adds a template for introducing other builders in future projects (with another arg to in the bash script)

This does change the bash script for direct conversion, but we don't have usage notes anywhere.